### PR TITLE
fix: infra/algorithm/key-generator/cosid  and nanoid pom

### DIFF
--- a/infra/algorithm/key-generator/cosid/pom.xml
+++ b/infra/algorithm/key-generator/cosid/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-infra-algorithm-key-generator-core</artifactId>
+            <artifactId>shardingsphere-infra-key-generator-core</artifactId>
             <version>${shardingsphere.version}</version>
         </dependency>
         <dependency>

--- a/infra/algorithm/key-generator/nanoid/pom.xml
+++ b/infra/algorithm/key-generator/nanoid/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-infra-algorithm-key-generator-core</artifactId>
+            <artifactId>shardingsphere-infra-key-generator-core</artifactId>
             <version>${shardingsphere.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
dependencies artifactId has change from `shardingsphere-infra-algorithm-key-generator-core` to `shardingsphere-infra-key-generator-core`